### PR TITLE
Validate message fields, enum constants and service rpc methods

### DIFF
--- a/protostuff-parser/src/main/antlr4/io/protostuff/compiler/parser/ProtoParser.g4
+++ b/protostuff-parser/src/main/antlr4/io/protostuff/compiler/parser/ProtoParser.g4
@@ -41,10 +41,13 @@ enumName
     : ident
     ;
 enumField
-    : enumFieldName ASSIGN INTEGER_VALUE fieldOptions? SEMICOLON
+    : enumFieldName ASSIGN enumFieldValue fieldOptions? SEMICOLON
     ;
 enumFieldName
     : ident
+    ;
+enumFieldValue
+    : INTEGER_VALUE
     ;
 extendBlock
     : EXTEND typeReference LCURLY extendBlockEntry* RCURLY SEMICOLON?
@@ -93,10 +96,10 @@ oneofName
     : ident
     ;
 oneofField
-    : typeReference fieldName ASSIGN INTEGER_VALUE fieldOptions? SEMICOLON
+    : typeReference fieldName ASSIGN tag fieldOptions? SEMICOLON
     ;
 oneofGroup
-    : GROUP fieldName ASSIGN INTEGER_VALUE LCURLY
+    : GROUP fieldName ASSIGN tag LCURLY
         (field
         | optionEntry
         | messageBlock
@@ -130,7 +133,7 @@ tag
     : INTEGER_VALUE
     ;
 groupBlock
-    : fieldModifier GROUP groupName ASSIGN INTEGER_VALUE LCURLY
+    : fieldModifier GROUP groupName ASSIGN tag LCURLY
         (field
         | optionEntry
         | messageBlock
@@ -150,7 +153,13 @@ ranges
     : range (COMMA range)*
     ;
 range
-    : INTEGER_VALUE ( TO ( INTEGER_VALUE | MAX ) )?
+    : rangeFrom ( TO ( rangeTo | MAX ) )?
+    ;
+rangeFrom
+    : INTEGER_VALUE
+    ;
+rangeTo
+    : INTEGER_VALUE
     ;
 reserved
     : RESERVED (ranges | fieldNames) SEMICOLON
@@ -162,7 +171,7 @@ fieldNameString
     : STRING_VALUE
     ;
 field
-    : fieldModifier? typeReference fieldName ASSIGN INTEGER_VALUE fieldOptions? SEMICOLON
+    : fieldModifier? typeReference fieldName ASSIGN tag fieldOptions? SEMICOLON
     ;
 fieldName
     : ident

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/ParserModule.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/ParserModule.java
@@ -5,26 +5,10 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 
+import io.protostuff.compiler.parser.*;
 import org.antlr.v4.runtime.ANTLRErrorListener;
 import org.antlr.v4.runtime.ANTLRErrorStrategy;
 import org.antlr.v4.runtime.BailErrorStrategy;
-
-import io.protostuff.compiler.parser.DefaultDescriptorProtoProvider;
-import io.protostuff.compiler.parser.ExtensionRegistratorPostProcessor;
-import io.protostuff.compiler.parser.FileDescriptorLoader;
-import io.protostuff.compiler.parser.FileDescriptorLoaderImpl;
-import io.protostuff.compiler.parser.FileReader;
-import io.protostuff.compiler.parser.FileReaderFactory;
-import io.protostuff.compiler.parser.Importer;
-import io.protostuff.compiler.parser.ImporterImpl;
-import io.protostuff.compiler.parser.ImportsPostProcessor;
-import io.protostuff.compiler.parser.OptionsPostProcessor;
-import io.protostuff.compiler.parser.ParseErrorLogger;
-import io.protostuff.compiler.parser.ProtoContext;
-import io.protostuff.compiler.parser.ProtoContextPostProcessor;
-import io.protostuff.compiler.parser.ProtoFileReader;
-import io.protostuff.compiler.parser.TypeRegistratorPostProcessor;
-import io.protostuff.compiler.parser.TypeResolverPostProcessor;
 
 import static io.protostuff.compiler.parser.DefaultDescriptorProtoProvider.DESCRIPTOR_PROTO;
 
@@ -50,6 +34,7 @@ public class ParserModule extends AbstractModule {
         postProcessors.addBinding().to(TypeResolverPostProcessor.class);
         postProcessors.addBinding().to(ExtensionRegistratorPostProcessor.class);
         postProcessors.addBinding().to(OptionsPostProcessor.class);
+        postProcessors.addBinding().to(UserTypeValidationPostProcessor.class);
 
         install(new FactoryModuleBuilder()
                 .implement(FileReader.class, ProtoFileReader.class)

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/model/Message.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/model/Message.java
@@ -33,6 +33,9 @@ public class Message extends AbstractUserTypeContainer
         return DescriptorType.MESSAGE;
     }
 
+    /**
+     * Returns all fields in this message, including group fields and oneof fields.
+     */
     public List<Field> getFields() {
         if (fields == null) {
             return Collections.emptyList();

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/model/Range.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/model/Range.java
@@ -32,6 +32,10 @@ public class Range extends AbstractElement {
         return to;
     }
 
+    public boolean contains(int tag) {
+        return tag >= from && tag <= to;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/parser/EnumParseListener.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/parser/EnumParseListener.java
@@ -46,7 +46,7 @@ public class EnumParseListener extends AbstractProtoParserListener {
         EnumConstant enumConstant = context.pop(EnumConstant.class);
         Enum e = context.peek(Enum.class);
         String name = ctx.enumFieldName().getText();
-        int number = Integer.decode(ctx.INTEGER_VALUE().getText());
+        int number = Integer.decode(ctx.enumFieldValue().getText());
         enumConstant.setName(name);
         enumConstant.setValue(number);
         enumConstant.setSourceCodeLocation(getSourceCodeLocation(ctx));

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/parser/UserTypeValidationPostProcessor.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/parser/UserTypeValidationPostProcessor.java
@@ -22,7 +22,24 @@ public class UserTypeValidationPostProcessor implements ProtoContextPostProcesso
         ProtoWalker.newInstance(context)
                 .onMessage(this::processMessage)
                 .onEnum(this::processEnum)
+                .onService(this::processService)
                 .walk();
+    }
+
+    private void processService(ProtoContext context, Service service) {
+        List<ServiceMethod> methods = service.getMethods();
+        checkDuplicateServiceMethodNames(methods);
+    }
+
+    private void checkDuplicateServiceMethodNames(List<ServiceMethod> methods) {
+        Map<String, ServiceMethod> methodsByName = new HashMap<>();
+        for (ServiceMethod method : methods) {
+            String name = method.getName();
+            if (methodsByName.containsKey(name)) {
+                throw new ParserException(method, "Duplicate service method name: '%s'", name);
+            }
+            methodsByName.put(name, method);
+        }
     }
 
     private void processEnum(ProtoContext context, Enum anEnum) {

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/parser/UserTypeValidationPostProcessor.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/parser/UserTypeValidationPostProcessor.java
@@ -1,0 +1,96 @@
+package io.protostuff.compiler.parser;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.protostuff.compiler.model.Field;
+import io.protostuff.compiler.model.Message;
+import io.protostuff.compiler.model.Range;
+
+import java.util.*;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class UserTypeValidationPostProcessor implements ProtoContextPostProcessor {
+
+    private final int MIN_TAG = 1;
+    private final int MAX_TAG = Field.MAX_TAG_VALUE;
+    private final int SYS_RESERVED_START = 19000;
+    private final int SYS_RESERVED_END = 19999;
+
+    @Override
+    public void process(ProtoContext context) {
+        ProtoWalker.newInstance(context)
+                .onMessage(this::processMessage)
+                .walk();
+    }
+
+    private void processMessage(ProtoContext context, Message message) {
+        List<Field> fields = message.getFields();
+        checkInvalidTags(fields);
+        checkDuplicateTags(fields);
+        checkDuplicateNames(fields);
+        checkReservedTags(message, fields);
+        checkReservedNames(message, fields);
+    }
+
+    private void checkReservedTags(Message message, List<Field> fields) {
+        List<Range> ranges = message.getReservedFieldRanges();
+        for (Field field : fields) {
+            int tag = field.getTag();
+            for (Range range : ranges) {
+                if (range.contains(tag)) {
+                    throw new ParserException(field, "Reserved field tag: %d", tag);
+                }
+            }
+        }
+    }
+
+    private void checkReservedNames(Message message, List<Field> fields) {
+        Set<String> names = new HashSet<>(message.getReservedFieldNames());
+        for (Field field : fields) {
+            String name = field.getName();
+            if (names.contains(name)) {
+                throw new ParserException(field, "Reserved field name: '%s'", name);
+            }
+        }
+    }
+
+    private void checkInvalidTags(List<Field> fields) {
+        for (Field field : fields) {
+            int tag = field.getTag();
+            if (!isValidTagValue(tag)) {
+                throw new ParserException(field, "Invalid tag: %d, allowed range is [%d, %d) and (%d, %d]",
+                        tag, MIN_TAG, SYS_RESERVED_START, SYS_RESERVED_END, MAX_TAG);
+            }
+        }
+    }
+
+    @VisibleForTesting
+    boolean isValidTagValue(int tag) {
+        return tag >= MIN_TAG && tag <= MAX_TAG
+                && !(tag >= SYS_RESERVED_START && tag <= SYS_RESERVED_END);
+    }
+
+    private void checkDuplicateTags(List<Field> fields) {
+        Map<Integer, Field> fieldByTag = new HashMap<>();
+        for (Field field : fields) {
+            int tag = field.getTag();
+            if (fieldByTag.containsKey(tag)) {
+                throw new ParserException(field, "Duplicate field tag: %d", tag);
+            }
+            fieldByTag.put(tag, field);
+        }
+    }
+
+    private void checkDuplicateNames(List<Field> fields) {
+        Map<String, Field> fieldByName = new HashMap<>();
+        for (Field field : fields) {
+            String name = field.getName();
+            if (fieldByName.containsKey(name)) {
+                throw new ParserException(field, "Duplicate field name: '%s'", name);
+            }
+            fieldByName.put(name, field);
+        }
+    }
+
+}

--- a/protostuff-parser/src/test/java/io/protostuff/compiler/parser/DuplicateTest.java
+++ b/protostuff-parser/src/test/java/io/protostuff/compiler/parser/DuplicateTest.java
@@ -28,11 +28,12 @@ public class DuplicateTest {
     }
 
     @Test
-    public void duplicate() throws Exception {
+    public void duplicate_type() throws Exception {
         Importer importer = injector.getInstance(Importer.class);
         thrown.expect(ParserException.class);
         thrown.expectMessage("Cannot register duplicate type: .protostuff_unittest.A " +
                 "[protostuff_unittest/duplicate.proto:9]");
         importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate.proto");
     }
+
 }

--- a/protostuff-parser/src/test/java/io/protostuff/compiler/parser/EnumTest.java
+++ b/protostuff-parser/src/test/java/io/protostuff/compiler/parser/EnumTest.java
@@ -1,0 +1,30 @@
+package io.protostuff.compiler.parser;
+
+import org.junit.Test;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class EnumTest extends AbstractParserTest {
+
+    @Test
+    public void duplicateConstantName() throws Exception {
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Duplicate enum constant name: 'X' " +
+                "[protostuff_unittest/duplicate_enum_constant_name.proto:7]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate_enum_constant_name.proto");
+    }
+
+    @Test
+    public void duplicateConstantValue() throws Exception {
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Duplicate enum constant value: 0 " +
+                "[protostuff_unittest/duplicate_enum_constant_value.proto:7]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate_enum_constant_value.proto");
+    }
+
+    @Test
+    public void duplicateConstantValue_allowed() throws Exception {
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate_enum_constant_value_allowed.proto");
+    }
+}

--- a/protostuff-parser/src/test/java/io/protostuff/compiler/parser/MessagesTest.java
+++ b/protostuff-parser/src/test/java/io/protostuff/compiler/parser/MessagesTest.java
@@ -15,4 +15,48 @@ public class MessagesTest extends AbstractParserTest {
         importer.importFile(new ClasspathFileReader(), "protostuff_unittest/messages_unresolved_field_type.proto");
     }
 
+    @Test
+    public void duplicate_field_tag() throws Exception {
+        Importer importer = injector.getInstance(Importer.class);
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Duplicate field tag: 1 " +
+                "[protostuff_unittest/duplicate_field_tag.proto:7]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate_field_tag.proto");
+    }
+
+    @Test
+    public void duplicate_field_name() throws Exception {
+        Importer importer = injector.getInstance(Importer.class);
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Duplicate field name: 'x' " +
+                "[protostuff_unittest/duplicate_field_name.proto:7]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate_field_name.proto");
+    }
+
+    @Test
+    public void invalid_field_tag() throws Exception {
+        Importer importer = injector.getInstance(Importer.class);
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Invalid tag: 19001, allowed range is [1, 19000) and (19999, 536870911] " +
+                "[protostuff_unittest/invalid_field_tag_value.proto:7]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/invalid_field_tag_value.proto");
+    }
+
+    @Test
+    public void reserved_field_tag() throws Exception {
+        Importer importer = injector.getInstance(Importer.class);
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Reserved field tag: 5 " +
+                "[protostuff_unittest/reserved_field_tag.proto:6]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/reserved_field_tag.proto");
+    }
+
+    @Test
+    public void reserved_field_name() throws Exception {
+        Importer importer = injector.getInstance(Importer.class);
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Reserved field name: 'x' " +
+                "[protostuff_unittest/reserved_field_name.proto:6]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/reserved_field_name.proto");
+    }
 }

--- a/protostuff-parser/src/test/java/io/protostuff/compiler/parser/ServiceTest.java
+++ b/protostuff-parser/src/test/java/io/protostuff/compiler/parser/ServiceTest.java
@@ -42,4 +42,12 @@ public class ServiceTest extends AbstractParserTest {
                 "[protostuff_unittest/services_bad_return_type.proto:7]");
         importer.importFile(new ClasspathFileReader(), "protostuff_unittest/services_bad_return_type.proto");
     }
+
+    @Test
+    public void duplicateMethodName() throws Exception {
+        thrown.expect(ParserException.class);
+        thrown.expectMessage("Duplicate service method name: 'action' " +
+                "[protostuff_unittest/duplicate_service_rpc_name.proto:7]");
+        importer.importFile(new ClasspathFileReader(), "protostuff_unittest/duplicate_service_rpc_name.proto");
+    }
 }

--- a/protostuff-parser/src/test/java/io/protostuff/compiler/parser/UserTypeValidationPostProcessorTest.java
+++ b/protostuff-parser/src/test/java/io/protostuff/compiler/parser/UserTypeValidationPostProcessorTest.java
@@ -1,0 +1,37 @@
+package io.protostuff.compiler.parser;
+
+import io.protostuff.compiler.model.Field;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Kostiantyn Shchepanovskyi
+ */
+public class UserTypeValidationPostProcessorTest {
+
+    private UserTypeValidationPostProcessor processor;
+
+    @Before
+    public void setUp() throws Exception {
+        processor = new UserTypeValidationPostProcessor();
+    }
+
+    @Test
+    public void isValidTagValue() throws Exception {
+        assertFalse(processor.isValidTagValue(-1));
+        assertFalse(processor.isValidTagValue(0));
+        assertFalse(processor.isValidTagValue(19000));
+        assertFalse(processor.isValidTagValue(19999));
+        assertFalse(processor.isValidTagValue(Field.MAX_TAG_VALUE+1));
+        assertTrue(processor.isValidTagValue(1));
+        assertTrue(processor.isValidTagValue(100));
+        assertTrue(processor.isValidTagValue(18999));
+        assertTrue(processor.isValidTagValue(20000));
+        assertTrue(processor.isValidTagValue(Field.MAX_TAG_VALUE-1));
+        assertTrue(processor.isValidTagValue(Field.MAX_TAG_VALUE));
+    }
+
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/comments_sample.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/comments_sample.proto
@@ -13,13 +13,14 @@ message Message {
     int32 c = 3 ; // another trailing field comment
 
     // leading map field comment
-    map<int32, int32> m1 = 3;
-    map<int32, int32> m2 = 4; // trailing map field comment
+    map<int32, int32> m1 = 4;
+    map<int32, int32> m2 = 5; // trailing map field comment
 
     // Oneof comment
     oneof Oneof {
         // leading oneof field comment
-        int32 x = 5; int32 y = 6; // trailing oneof field comment
+        int32 x = 6;
+        int32 y = 7; // trailing oneof field comment
     }
 }
 

--- a/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_enum_constant_name.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_enum_constant_name.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+enum A {
+    X = 0;
+    X = 1;
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_enum_constant_value.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_enum_constant_value.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+enum A {
+    X = 0;
+    Y = 0;
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_enum_constant_value_allowed.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_enum_constant_value_allowed.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+enum A {
+    option allow_alias = true;
+    X = 0;
+    Y = 0;
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_field_name.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_field_name.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+message A {
+    optional int32 x = 1;
+    optional int32 x = 2;
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_field_tag.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_field_tag.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+message A {
+    optional int32 x = 1;
+    optional int32 y = 1;
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_service_rpc_name.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/duplicate_service_rpc_name.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+service A {
+    rpc action (M) returns (M);
+    rpc action (M) returns (M);
+}
+
+message M {
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/imports_a.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/imports_a.proto
@@ -6,5 +6,5 @@ import "protostuff_unittest/imports_b.proto";
 
 message A {
     B b = 1;
-    C c = 1;
+    C c = 2;
 }

--- a/protostuff-parser/src/test/resources/protostuff_unittest/invalid_field_tag_value.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/invalid_field_tag_value.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+message A {
+    // reserved for internal protobuf usage
+    optional int32 x = 19001;
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/reserved_field_name.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/reserved_field_name.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+message A {
+    optional int32 x = 5;
+    reserved "x";
+}

--- a/protostuff-parser/src/test/resources/protostuff_unittest/reserved_field_tag.proto
+++ b/protostuff-parser/src/test/resources/protostuff_unittest/reserved_field_tag.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package protostuff_unittest;
+
+message A {
+    optional int32 x = 5;
+    reserved 3 to 7;
+}


### PR DESCRIPTION
Validate message field tags and names:

 - tag should be in range [1, MAX_TAG]
 - tag cannot be in range reserved for internal protobuf usage
 - tags should not be duplicated
 - names should not be duplicated
 - check for reserved ranges and names

Validate enum constants:

 - values should not be duplicated (unless option 'allow_alias' is set)
 - names should not be duplicated

Validate service rpc methods:

 - names should not be duplicated