### PR TITLE
Support multiple templates in maven plugin st4 goal

### DIFF
--- a/protostuff-cli/src/main/java/io/protostuff/compiler/cli/ProtostuffCompilerCLI.java
+++ b/protostuff-cli/src/main/java/io/protostuff/compiler/cli/ProtostuffCompilerCLI.java
@@ -20,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -132,7 +133,8 @@ public class ProtostuffCompilerCLI extends ProtostuffCompiler {
                 return;
             }
             if (cmd.hasOption(TEMPLATE)) {
-                builder.putOptions(CompilerModule.TEMPLATE_OPTION, cmd.getOptionValue(TEMPLATE));
+                List<String> templates = Collections.singletonList(cmd.getOptionValue(TEMPLATE));
+                builder.putOptions(CompilerModule.TEMPLATES_OPTION, templates);
             }
             if (cmd.hasOption(EXTENSIONS)) {
                 builder.putOptions(CompilerModule.EXTENSIONS_OPTION, cmd.getOptionValue(EXTENSIONS));

--- a/protostuff-generator/src/main/java/io/protostuff/generator/ExtensibleStCompilerFactory.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/ExtensibleStCompilerFactory.java
@@ -2,6 +2,8 @@ package io.protostuff.generator;
 
 import org.stringtemplate.v4.AttributeRenderer;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -9,5 +11,5 @@ import java.util.Map;
  */
 public interface ExtensibleStCompilerFactory {
 
-    ProtoCompiler create(String template, ExtensionProvider extensionProvider);
+    ProtoCompiler create(Collection<String> templates, ExtensionProvider extensionProvider);
 }

--- a/protostuff-maven-plugin/src/main/java/io/protostuff/compiler/maven/St4GeneratorMojo.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/compiler/maven/St4GeneratorMojo.java
@@ -15,6 +15,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.apache.maven.plugins.annotations.LifecyclePhase.GENERATE_TEST_SOURCES;
@@ -36,8 +39,11 @@ public class St4GeneratorMojo extends AbstractGeneratorMojo {
     private File target;
 
 
-    @Parameter(defaultValue = "io/protostuff/generator/java/main.stg")
+    @Parameter
     private String template;
+
+    @Parameter
+    private List<String> templates;
 
     @Parameter
     private String extensions;
@@ -49,11 +55,18 @@ public class St4GeneratorMojo extends AbstractGeneratorMojo {
         ProtostuffCompiler compiler = new ProtostuffCompiler();
         final Path sourcePath = getSourcePath();
         String output = calculateOutput();
+        Set<String> allTemplates = new LinkedHashSet<>();
+        if (template != null) {
+            allTemplates.add(template);
+        }
+        if (templates != null) {
+            allTemplates.addAll(templates);
+        }
         ImmutableModuleConfiguration.Builder builder = ImmutableModuleConfiguration.builder()
                 .name("java")
                 .includePaths(singletonList(sourcePath))
                 .generator(CompilerModule.ST4_COMPILER)
-                .putOptions(CompilerModule.TEMPLATE_OPTION, template)
+                .putOptions(CompilerModule.TEMPLATES_OPTION, allTemplates)
                 .putOptions(CompilerModule.EXTENSIONS_OPTION, extensions)
                 .output(output);
         PathMatcher protoMatcher = FileSystems.getDefault().getPathMatcher("glob:**/*.proto");

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/model/Module.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/model/Module.java
@@ -17,6 +17,6 @@ public interface Module {
 
     String getOutput();
 
-    Map<String, String> getOptions();
+    Map<String, Object> getOptions();
 
 }

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/model/ModuleConfiguration.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/model/ModuleConfiguration.java
@@ -49,6 +49,6 @@ public interface ModuleConfiguration {
     /**
      * Map of custom settings passed to the generator.
      */
-    Map<String, String> getOptions();
+    Map<String, Object> getOptions();
 
 }


### PR DESCRIPTION
Sample:

```
<execution>
	<id>generate-test-java-sources</id>
	<phase>generate-test-sources</phase>
	<goals>
		<goal>st4</goal>
	</goals>
	<configuration>
		<extensions>com.playtech.live.platform.generator.LiveJavaExtensionProvider</extensions>
		<templates>
			<template>pt/live/generator/java.stg</template>
			<template>pt/live/generator/java_service_api.stg</template>
			<template>pt/live/generator/java_service_base.stg</template>
			<template>pt/live/generator/java_abstract_service.stg</template>
		</templates>
	</configuration>
</execution>
```