### PR TITLE
Fix default value for proto2 enums with non-zero first value

### DIFF
--- a/protostuff-generator/src/main/resources/io/protostuff/generator/java/message-base.stg
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/java/message-base.stg
@@ -32,6 +32,11 @@ message_bit_field(name) ::= <<
 private int <name>;
 >>
 
+
+default_enum_value(enum) ::= <%
+<first(enum.constants):{constant|<constant.javaName>}>
+%>
+
 field_initializer(field) ::= <%
 <if(field.map)>
 this.<field.javaName> = java.util.Collections.emptyMap();
@@ -39,7 +44,7 @@ this.<field.javaName> = java.util.Collections.emptyMap();
 this.<field.javaName> = java.util.Collections.emptyList();
 <elseif(field.oneofPart)>
 <elseif(field.type.enum)>
-this.<field.javaName> = 0;
+this.<field.javaName> = <field.javaType>.<field.type:default_enum_value()>.getNumber();
 <else>
 this.<field.javaName> = <field.javaDefaultValue>;
 <endif>

--- a/protostuff-it/src/test/java/io/protostuff/it/EnumTest.java
+++ b/protostuff-it/src/test/java/io/protostuff/it/EnumTest.java
@@ -1,5 +1,7 @@
 package io.protostuff.it;
 
+import io.protostuff.it.enum_test.Proto2EnumDefaultValueNonZero;
+import io.protostuff.it.enum_test.Proto2Message;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -121,5 +123,11 @@ public class EnumTest {
         Assert.assertEquals(3, NestedEnum.HUNDRED.ordinal());
         // Unrecognized goes last
         Assert.assertEquals(4, NestedEnum.UNRECOGNIZED.ordinal());
+    }
+
+    @Test
+    public void proto2_enumDefaultValue() throws Exception {
+        Proto2Message message = Proto2Message.getDefaultInstance();
+        Assert.assertEquals(Proto2EnumDefaultValueNonZero.FIRST, message.getE());
     }
 }

--- a/protostuff-it/src/test/proto/io/protostuff/it/proto2_enum.proto
+++ b/protostuff-it/src/test/proto/io/protostuff/it/proto2_enum.proto
@@ -1,0 +1,15 @@
+syntax = "proto2";
+
+package io.protostuff.it;
+
+option java_package = "io.protostuff.it.enum_test";
+
+enum Proto2EnumDefaultValueNonZero {
+    FIRST = 1;
+    SECOND = 2;
+    HUNDRED = 100;
+}
+
+message Proto2Message {
+    optional Proto2EnumDefaultValueNonZero e = 1;
+}


### PR DESCRIPTION
For following test:

```java
@Test
public void proto2_enumDefaultValue() throws Exception {
    Proto2Message message = Proto2Message.getDefaultInstance();
    Assert.assertEquals(Proto2EnumDefaultValueNonZero.FIRST, message.getE());
}
```

```proto
enum Proto2EnumDefaultValueNonZero {
    FIRST = 1;
    SECOND = 2;
    HUNDRED = 100;
}

message Proto2Message {
    optional Proto2EnumDefaultValueNonZero e = 1;
}
```

Before this fix default value for enum with non-zero first element was `UNRECOGNIZED`.
