### PR TITLE
Static documentation pages

### DIFF
--- a/protostuff-generator/pom.xml
+++ b/protostuff-generator/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.pegdown</groupId>
             <artifactId>pegdown</artifactId>
-            <version>1.5.0</version>
+            <version>1.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>

--- a/protostuff-generator/src/main/java/io/protostuff/generator/CompilerModule.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/CompilerModule.java
@@ -7,6 +7,7 @@ import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import io.protostuff.generator.html.HtmlGenerator;
 import io.protostuff.generator.java.JavaExtensionProvider;
+import org.pegdown.PegDownProcessor;
 
 import javax.inject.Inject;
 import java.io.FileOutputStream;
@@ -60,6 +61,11 @@ public class CompilerModule extends AbstractModule {
         compilers.addBinding(HTML_COMPILER).to(HtmlGenerator.class);
         compilers.addBinding(JAVA_COMPILER).toProvider(JavaCompilerProvider.class);
         compilers.addBinding(ST4_COMPILER).toProvider(St4CompilerProvider.class);
+    }
+
+    @Provides
+    PegDownProcessor pegDownProcessor() {
+        return new PegDownProcessor();
     }
 
     @Provides

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/HtmlGenerator.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/HtmlGenerator.java
@@ -1,18 +1,22 @@
 package io.protostuff.generator.html;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-
+import com.google.common.base.Throwables;
 import io.protostuff.compiler.model.Module;
 import io.protostuff.generator.CompilerUtils;
 import io.protostuff.generator.ProtoCompiler;
 import io.protostuff.generator.html.json.enumeration.JsonEnumGenerator;
 import io.protostuff.generator.html.json.index.JsonIndexGenerator;
 import io.protostuff.generator.html.json.message.JsonMessageGenerator;
+import io.protostuff.generator.html.json.pages.JsonPagesGenerator;
 import io.protostuff.generator.html.json.proto.JsonProtoGenerator;
 import io.protostuff.generator.html.json.service.JsonServiceGenerator;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.List;
+import javax.inject.Inject;
 
 /**
  * @author Kostiantyn Shchepanovskyi
@@ -63,26 +67,30 @@ public class HtmlGenerator implements ProtoCompiler {
     };
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HtmlGenerator.class);
+    public static final String PAGES = "pages";
     private final CompilerUtils compilerUtils;
     private final JsonIndexGenerator indexGenerator;
     private final JsonEnumGenerator enumGenerator;
     private final JsonMessageGenerator messageGenerator;
     private final JsonServiceGenerator serviceGenerator;
     private final JsonProtoGenerator protoGenerator;
+    private final JsonPagesGenerator pagesGenerator;
 
     @Inject
     public HtmlGenerator(CompilerUtils compilerUtils,
-                         JsonIndexGenerator indexGenerator,
-                         JsonEnumGenerator enumGenerator,
-                         JsonMessageGenerator messageGenerator,
-                         JsonServiceGenerator serviceGenerator,
-                         JsonProtoGenerator protoGenerator) {
+            JsonIndexGenerator indexGenerator,
+            JsonEnumGenerator enumGenerator,
+            JsonMessageGenerator messageGenerator,
+            JsonServiceGenerator serviceGenerator,
+            JsonProtoGenerator protoGenerator,
+            JsonPagesGenerator pagesGenerator) {
         this.compilerUtils = compilerUtils;
         this.indexGenerator = indexGenerator;
         this.enumGenerator = enumGenerator;
         this.messageGenerator = messageGenerator;
         this.serviceGenerator = serviceGenerator;
         this.protoGenerator = protoGenerator;
+        this.pagesGenerator = pagesGenerator;
     }
 
     @Override
@@ -92,8 +100,26 @@ public class HtmlGenerator implements ProtoCompiler {
         messageGenerator.compile(module);
         serviceGenerator.compile(module);
         protoGenerator.compile(module);
+        pagesGenerator.compile(module);
         copy(HTML_RESOURCE_BASE, module.getOutput() + "/", STATIC_RESOURCES);
         copy(WEBJARS_RESOURCE_PREFIX, module.getOutput() + "/libs/", STATIC_LIBS);
+        copyStaticPages(module);
+    }
+
+    private void copyStaticPages(Module module) {
+        try {
+            @SuppressWarnings("unchecked")
+            List<StaticPage> pages = (List<StaticPage>) module.getOptions().get(PAGES);
+            if (pages != null) {
+                File pagesDir = new File(module.getOutput() + "/pages/");
+                FileUtils.forceMkdir(pagesDir);
+                for (StaticPage page : pages) {
+                    FileUtils.copyFileToDirectory(page.getFile(), pagesDir);
+                }
+            }
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
     }
 
     private void copy(String source, String target, String[] files) {

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/StaticPage.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/StaticPage.java
@@ -1,0 +1,54 @@
+package io.protostuff.generator.html;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+import java.io.File;
+
+public class StaticPage {
+
+    private String name;
+    private File file;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public void setFile(File file) {
+        this.file = file;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StaticPage page = (StaticPage) o;
+        return Objects.equal(name, page.name) &&
+                Objects.equal(file, page.file);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, file);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                .add("name", name)
+                .add("file", file)
+                .toString();
+    }
+}

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/index/JsonIndexGenerator.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/index/JsonIndexGenerator.java
@@ -24,7 +24,7 @@ public final class JsonIndexGenerator extends AbstractJsonGenerator {
     @Override
     public void compile(Module module) {
         List<JsonTreeNode> root = new ArrayList<>();
-        module.getProtos().stream()
+        module.getProtos()
                 .forEach(proto -> root.add(JsonTreeNode.newBuilder()
                         .label(proto.getFilename())
                         .data(NodeData.newBuilder()
@@ -39,7 +39,7 @@ public final class JsonIndexGenerator extends AbstractJsonGenerator {
 
     private List<JsonTreeNode> processProto(Proto proto) {
         List<JsonTreeNode> result = new ArrayList<>();
-        proto.getServices().stream()
+        proto.getServices()
                 .forEach(service -> result.add(JsonTreeNode.newBuilder()
                         .label(service.getName())
                         .data(NodeData.newBuilder()
@@ -53,7 +53,7 @@ public final class JsonIndexGenerator extends AbstractJsonGenerator {
 
     private List<JsonTreeNode> processContainer(UserTypeContainer proto) {
         List<JsonTreeNode> result = new ArrayList<>();
-        proto.getEnums().stream()
+        proto.getEnums()
                 .forEach(anEnum -> result.add(JsonTreeNode.newBuilder()
                         .label(anEnum.getName())
                         .data(NodeData.newBuilder()

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPageGenerator.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPageGenerator.java
@@ -1,0 +1,55 @@
+package io.protostuff.generator.html.json.pages;
+
+import static io.protostuff.generator.html.HtmlGenerator.PAGES;
+
+import com.google.common.base.Throwables;
+import io.protostuff.compiler.model.Module;
+import io.protostuff.generator.OutputStreamFactory;
+import io.protostuff.generator.html.StaticPage;
+import io.protostuff.generator.html.json.AbstractJsonGenerator;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.pegdown.PegDownProcessor;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import javax.inject.Inject;
+
+public class JsonPageGenerator extends AbstractJsonGenerator {
+
+    private final PegDownProcessor pegDownProcessor;
+
+    @Inject
+    public JsonPageGenerator(OutputStreamFactory outputStreamFactory, PegDownProcessor pegDownProcessor) {
+        super(outputStreamFactory);
+        this.pegDownProcessor = pegDownProcessor;
+    }
+
+    @Override
+    public void compile(Module module) {
+        try {
+            @SuppressWarnings("unchecked")
+            List<StaticPage> pages = (List<StaticPage>) module.getOptions().get(PAGES);
+            if (pages != null) {
+                pages.forEach(page -> {
+                    try {
+                        String content = new String(Files.readAllBytes(page.getFile().toPath()), StandardCharsets.UTF_8);
+                        String html = pegDownProcessor.markdownToHtml(content);
+                        String baseName = FilenameUtils.getBaseName(page.getFile().getName());
+                        Page p = ImmutablePage.builder()
+                                .name(page.getName())
+                                .content(html)
+                                .build();
+                        write(module.getOutput() + "/data/pages/" + baseName + ".json", p);
+                    } catch (Exception e) {
+                        throw Throwables.propagate(e);
+                    }
+                });
+            }
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPagesGenerator.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPagesGenerator.java
@@ -1,0 +1,36 @@
+package io.protostuff.generator.html.json.pages;
+
+import static io.protostuff.generator.html.HtmlGenerator.PAGES;
+
+import io.protostuff.compiler.model.Module;
+import io.protostuff.generator.OutputStreamFactory;
+import io.protostuff.generator.html.StaticPage;
+import io.protostuff.generator.html.json.AbstractJsonGenerator;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+
+public class JsonPagesGenerator extends AbstractJsonGenerator {
+
+    @Inject
+    public JsonPagesGenerator(OutputStreamFactory outputStreamFactory) {
+        super(outputStreamFactory);
+    }
+
+    @Override
+    public void compile(Module module) {
+        String output = module.getOutput() + "/data/pages.json";
+        @SuppressWarnings("unchecked")
+        List<StaticPage> pages = (List<StaticPage>) module.getOptions().get(PAGES);
+        if (pages != null) {
+            List<Page> root = pages.stream()
+                    .map(page -> ImmutablePage.builder()
+                            .name(page.getName())
+                            .ref(page.getFile().getName())
+                            .build())
+                    .collect(Collectors.toList());
+            write(output, root);
+        }
+    }
+}

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPagesIndexGenerator.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPagesIndexGenerator.java
@@ -6,15 +6,16 @@ import io.protostuff.compiler.model.Module;
 import io.protostuff.generator.OutputStreamFactory;
 import io.protostuff.generator.html.StaticPage;
 import io.protostuff.generator.html.json.AbstractJsonGenerator;
+import org.apache.commons.io.FilenameUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 
-public class JsonPagesGenerator extends AbstractJsonGenerator {
+public class JsonPagesIndexGenerator extends AbstractJsonGenerator {
 
     @Inject
-    public JsonPagesGenerator(OutputStreamFactory outputStreamFactory) {
+    public JsonPagesIndexGenerator(OutputStreamFactory outputStreamFactory) {
         super(outputStreamFactory);
     }
 
@@ -24,10 +25,10 @@ public class JsonPagesGenerator extends AbstractJsonGenerator {
         @SuppressWarnings("unchecked")
         List<StaticPage> pages = (List<StaticPage>) module.getOptions().get(PAGES);
         if (pages != null) {
-            List<Page> root = pages.stream()
-                    .map(page -> ImmutablePage.builder()
+            List<PageIndexItem> root = pages.stream()
+                    .map(page -> ImmutablePageIndexItem.builder()
                             .name(page.getName())
-                            .ref(page.getFile().getName())
+                            .ref(FilenameUtils.getBaseName(page.getFile().getName()))
                             .build())
                     .collect(Collectors.toList());
             write(output, root);

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/Page.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/Page.java
@@ -1,0 +1,15 @@
+package io.protostuff.generator.html.json.pages;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutablePage.class)
+@JsonDeserialize(as = ImmutablePage.class)
+public interface Page {
+
+    String name();
+
+    String ref();
+}

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/PageIndexItem.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/PageIndexItem.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
-@JsonSerialize(as = ImmutablePage.class)
-@JsonDeserialize(as = ImmutablePage.class)
-public interface Page {
+@JsonSerialize(as = ImmutablePageIndexItem.class)
+@JsonDeserialize(as = ImmutablePageIndexItem.class)
+public interface PageIndexItem {
 
     String name();
 
-    String content();
+    String ref();
 }

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/css/theme.css
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/css/theme.css
@@ -32,7 +32,13 @@ body {
 }
 
 .sidebar a {
-    color: #428bca;
+    color: #3572b0;
+}
+
+.sidebar .pages ul {
+    padding-left: 16px;
+    list-style-type: none;
+    white-space: nowrap;
 }
 
 .sidebar .list-group-item {

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/index.html
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/index.html
@@ -59,10 +59,17 @@
     </div>
 </nav>
 
-<div class="container-fluid" ng-controller="TreeCtrl as treeCtrl">
+<div class="container-fluid">
     <div class="row">
-        <div class="col-sm-4 col-md-3 sidebar">
+        <div ng-controller="TreeCtrl as treeCtrl" class="col-sm-4 col-md-3 sidebar">
+            <div id="pages" class="pages">
+                <h1>Documents</h1>
+                <ul>
+                    <li ng-repeat="page in treeCtrl.pages"><a href="#/pages/{{page.ref}}">{{page.name}}</a></li>
+                </ul>
+            </div>
             <div id="tree">
+                <h1>Type Hierarchy</h1>
                 <abn-tree
                         tree-data="treeCtrl.treeData"
                         tree-control="treeCtrl.treeService.getTree()"

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/app.js
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/app.js
@@ -52,5 +52,9 @@ app.config(['$routeProvider', function ($routeProvider) {
         templateUrl: 'partials/proto-detail.html',
         controller: 'ProtoDetailCtrl'
     });
+    $routeProvider.when('/pages/:pageId', {
+        templateUrl: 'partials/page.html',
+        controller: 'PageCtrl'
+    });
     $routeProvider.otherwise({redirectTo: '/'});
 }]);

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/controllers.js
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/controllers.js
@@ -117,3 +117,15 @@ function SearchCtrl($log, $location, TreeService, $scope) {
     }
 }
 controllers.controller('SearchCtrl', ['$log', '$location', 'TreeService', '$scope', SearchCtrl]);
+
+function PageCtrl($scope, $http, $routeParams, $sce) {
+    var pageId;
+    $scope.pageId = pageId = $routeParams.pageId;
+    $http.get('data/pages/' + pageId + '.json')
+        .success(function (data) {
+            $scope.page = {};
+            $scope.page.name = data.name;
+            $scope.page.content = $sce.trustAsHtml(data.content);
+        });
+}
+controllers.controller('PageCtrl', ['$scope', '$http', '$routeParams', '$sce', PageCtrl]);

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/controllers.js
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/controllers.js
@@ -8,14 +8,21 @@ function TreeCtrl($location, ProtoDataFactory, $q, TreeService) {
     self.show = show;
 
     loadData().then(function (data) {
-        self.treeData = data;
-        TreeService.setTreeData(data);
+        self.treeData = data.typeIndex;
+        self.pages = data.pageIndex;
+        TreeService.setTreeData(data.typeIndex);
     });
 
     function loadData() {
         var deferred = $q.defer();
-        ProtoDataFactory.get().then(function (data) {
-            deferred.resolve(data);
+        var typeIndex = ProtoDataFactory.getTypeIndex();
+        var pageIndex = ProtoDataFactory.getPageIndex();
+        $q.all([typeIndex, pageIndex]).then(function (data) {
+            var result = {
+                "typeIndex": data[0],
+                "pageIndex": data[1]
+            };
+            deferred.resolve(result);
         });
         return deferred.promise;
     }
@@ -28,7 +35,8 @@ function TreeCtrl($location, ProtoDataFactory, $q, TreeService) {
         }
     }
 }
-controllers.controller('TreeCtrl', ['$location', 'ProtoDataFactory', '$q', 'TreeService', TreeCtrl]);
+controllers.controller('TreeCtrl',
+                       ['$location', 'ProtoDataFactory', '$q', 'TreeService', TreeCtrl]);
 
 function TypeListCtrl($scope, $http) {
 
@@ -55,7 +63,6 @@ function ProtoDetailCtrl($scope, $http, $routeParams) {
 }
 controllers.controller('ProtoDetailCtrl', ['$scope', '$http', '$routeParams', ProtoDetailCtrl]);
 
-
 function SearchCtrl($log, $location, TreeService, $scope) {
     var self = this;
 
@@ -80,7 +87,6 @@ function SearchCtrl($log, $location, TreeService, $scope) {
         self.states = searchFunction(TreeService.getTreeData(), []);
         fuse = new Fuse(self.states, options);
     });
-
 
     function filterItems(query) {
         return query ? fuse.search(query) : self.states;

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/factories.js
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/js/factories.js
@@ -2,8 +2,14 @@ var factories = angular.module('factories', []);
 
 function ProtoDataFactory($http) {
     var protoDataService = {
-        get: function () {
+        getTypeIndex: function () {
             return $http.get('data/index.json').then(function (response) {
+                return response.data;
+            });
+        },
+
+        getPageIndex: function () {
+            return $http.get('data/pages.json').then(function (response) {
                 return response.data;
             });
         }

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/html/partials/page.html
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/html/partials/page.html
@@ -1,0 +1,9 @@
+<div class="page-header" title="{{page.name}}">
+    <h1>
+        <span class="code">{{page.name}}</span>
+    </h1>
+</div>
+
+<div ng-if="page.content">
+    <span ng-bind-html="page.content"></span>
+</div>

--- a/protostuff-maven-plugin/src/main/java/io/protostuff/compiler/maven/HtmlGeneratorMojo.java
+++ b/protostuff-maven-plugin/src/main/java/io/protostuff/compiler/maven/HtmlGeneratorMojo.java
@@ -2,6 +2,8 @@ package io.protostuff.compiler.maven;
 
 import io.protostuff.compiler.model.ImmutableModuleConfiguration;
 import io.protostuff.generator.CompilerModule;
+import io.protostuff.generator.html.HtmlGenerator;
+import io.protostuff.generator.html.StaticPage;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -18,10 +20,10 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 
 import io.protostuff.compiler.model.ModuleConfiguration;
 import io.protostuff.generator.ProtostuffCompiler;
-import io.protostuff.generator.html.HtmlGenerator;
 
 import static java.util.Collections.singletonList;
 import static org.apache.maven.plugins.annotations.ResolutionScope.COMPILE_PLUS_RUNTIME;
@@ -39,6 +41,9 @@ public class HtmlGeneratorMojo extends AbstractGeneratorMojo {
     @Parameter(defaultValue = "${project.build.directory}/generated-html")
     private File target;
 
+    @Parameter
+    private List<StaticPage> pages;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         super.execute();
@@ -50,6 +55,9 @@ public class HtmlGeneratorMojo extends AbstractGeneratorMojo {
                 .includePaths(singletonList(sourcePath))
                 .generator(CompilerModule.HTML_COMPILER)
                 .output(target.getAbsolutePath());
+        if (pages != null) {
+            builder.putOptions(HtmlGenerator.PAGES, pages);
+        }
         PathMatcher protoMatcher = FileSystems.getDefault().getPathMatcher("glob:**/*.proto");
         try {
             Files.walkFileTree(sourcePath, new SimpleFileVisitor<Path>() {


### PR DESCRIPTION
Add functionality for adding static pages to generated documentation.

Using maven plugin:

```xml
<execution>
    <id>generate-proto-documentation</id>
    <phase>generate-sources</phase>
    <goals>
        <goal>html</goal>
    </goals>
    <configuration>
        <source>${project.build.directory}/client-package-proto</source>
        <pages>
            <page>
                <name>Index</name>
                <file>${project.basedir}/index.md</file>
            </page>
            <page>
                <name>Changelog</name>
                <file>${project.basedir}/changelog.md</file>
            </page>
        </pages>
    </configuration>
</execution>
```