### PR TITLE
UML extension for markdown

### DIFF
--- a/protostuff-generator/pom.xml
+++ b/protostuff-generator/pom.xml
@@ -37,6 +37,11 @@
             <version>1.6.0</version>
         </dependency>
         <dependency>
+            <groupId>net.sourceforge.plantuml</groupId>
+            <artifactId>plantuml</artifactId>
+            <version>8048</version>
+        </dependency>
+        <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>angularjs</artifactId>
             <version>1.5.8</version>

--- a/protostuff-generator/src/main/java/io/protostuff/generator/CompilerModule.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/CompilerModule.java
@@ -77,7 +77,7 @@ public class CompilerModule extends AbstractModule {
 
     @Provides
     PegDownProcessor pegDownProcessor() {
-        return new PegDownProcessor(SMARTYPANTS
+        PegDownProcessor processor = new PegDownProcessor(SMARTYPANTS
                 | ABBREVIATIONS
                 | AUTOLINKS
                 | TABLES
@@ -90,6 +90,7 @@ public class CompilerModule extends AbstractModule {
                 | RELAXEDHRULES
                 | TASKLISTITEMS
         );
+        return processor;
     }
 
     @Provides

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPageGenerator.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/json/pages/JsonPageGenerator.java
@@ -7,14 +7,17 @@ import io.protostuff.compiler.model.Module;
 import io.protostuff.generator.OutputStreamFactory;
 import io.protostuff.generator.html.StaticPage;
 import io.protostuff.generator.html.json.AbstractJsonGenerator;
-import org.apache.commons.io.FileUtils;
+import io.protostuff.generator.html.uml.PlantUmlVerbatimSerializer;
 import org.apache.commons.io.FilenameUtils;
+import org.pegdown.LinkRenderer;
 import org.pegdown.PegDownProcessor;
+import org.pegdown.VerbatimSerializer;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 
 public class JsonPageGenerator extends AbstractJsonGenerator {
@@ -36,7 +39,9 @@ public class JsonPageGenerator extends AbstractJsonGenerator {
                 pages.forEach(page -> {
                     try {
                         String content = new String(Files.readAllBytes(page.getFile().toPath()), StandardCharsets.UTF_8);
-                        String html = pegDownProcessor.markdownToHtml(content);
+                        Map<String, VerbatimSerializer> serializers = new HashMap<>();
+                        PlantUmlVerbatimSerializer.addToMap(serializers);
+                        String html = pegDownProcessor.markdownToHtml(content, new LinkRenderer(), serializers);
                         String baseName = FilenameUtils.getBaseName(page.getFile().getName());
                         Page p = ImmutablePage.builder()
                                 .name(page.getName())

--- a/protostuff-generator/src/main/java/io/protostuff/generator/html/uml/PlantUmlVerbatimSerializer.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/html/uml/PlantUmlVerbatimSerializer.java
@@ -1,0 +1,97 @@
+package io.protostuff.generator.html.uml;
+
+import net.sourceforge.plantuml.FileFormat;
+import net.sourceforge.plantuml.FileFormatOption;
+import net.sourceforge.plantuml.SourceStringReader;
+import org.parboiled.common.Base64;
+import org.pegdown.Printer;
+import org.pegdown.VerbatimSerializer;
+import org.pegdown.ast.VerbatimNode;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Source: https://bitbucket.org/peachjean/pegdown-uml/src/3e053df209e8?at=default
+ * Author: Jared Bunting, jared.bunting@peachjean.com
+ * Licensed under GNU General Public License (GPL)
+ * http://www.gnu.org/licenses/gpl.txt
+ */
+public class PlantUmlVerbatimSerializer implements VerbatimSerializer {
+
+    public static void addToMap(final Map<String, VerbatimSerializer> serializerMap) {
+        PlantUmlVerbatimSerializer serializer = new PlantUmlVerbatimSerializer();
+        for (Type type : Type.values()) {
+            serializerMap.put(type.name(), serializer);
+        }
+    }
+
+    @Override
+    public void serialize(VerbatimNode node, Printer printer) {
+        Type type = Type.valueOf(node.getType());
+
+        String formatted = type.wrap(node.getText());
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SourceStringReader reader = new SourceStringReader(formatted);
+        String desc;
+        try {
+            desc = reader.generateImage(baos, type.getFormatOption());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not generate uml for node " + node, e);
+        }
+        final String rendered = type.render(baos.toByteArray(), desc);
+        printer.print(rendered);
+    }
+
+    enum Type {
+        uml(OutputType.svg),
+        dot(OutputType.svg),
+        jcckit(OutputType.png),
+        ditaa(OutputType.png);
+
+        private final OutputType outputType;
+
+        Type(final OutputType outputType) {
+            this.outputType = outputType;
+        }
+
+        public String wrap(final String originalText) {
+            return "@start" + this.toString() + "\n" + originalText + "@end" + this.toString() + "\n";
+        }
+
+        public FileFormatOption getFormatOption() {
+            return this.outputType.getFormatOption();
+        }
+
+        public String render(byte[] bytes, final String desc) {
+            return this.outputType.render(bytes, desc);
+        }
+    }
+
+    enum OutputType {
+        svg {
+            public FileFormatOption getFormatOption() {
+                return new FileFormatOption(FileFormat.SVG);
+            }
+
+            public String render(byte[] bytes, final String desc) {
+                return new String(bytes);
+            }
+        }, png {
+            @Override
+            public FileFormatOption getFormatOption() {
+                return new FileFormatOption(FileFormat.PNG);
+            }
+
+            @Override
+            public String render(final byte[] bytes, final String desc) {
+                return String.format("<img alt=\"%s\" src=\"data:image/png;base64,%s\"/>", desc, Base64.rfc2045().encodeToString(bytes, false));
+            }
+        };
+
+        public abstract FileFormatOption getFormatOption();
+
+        public abstract String render(byte[] bytes, final String desc);
+    }
+}


### PR DESCRIPTION
User can use following syntax in order to generate UML diagram inside of markdown document:

    ```uml
        Alice-->Bob: Hello
    ```