### PR TITLE
Fixes an issue where defaults on enums were not being honoured.

### DIFF
--- a/protostuff-generator/src/main/java/io/protostuff/generator/java/MessageFieldUtil.java
+++ b/protostuff-generator/src/main/java/io/protostuff/generator/java/MessageFieldUtil.java
@@ -5,8 +5,10 @@ import static io.protostuff.compiler.model.ScalarFieldType.BYTES;
 import static io.protostuff.compiler.model.ScalarFieldType.STRING;
 import static io.protostuff.compiler.parser.MessageParseListener.MAP_ENTRY_KEY;
 import static io.protostuff.compiler.parser.MessageParseListener.MAP_ENTRY_VALUE;
+import static io.protostuff.compiler.parser.OptionsPostProcessor.DEFAULT;
 
 import com.google.common.collect.ImmutableMap;
+import io.protostuff.compiler.model.DynamicMessage;
 import io.protostuff.compiler.model.Enum;
 import io.protostuff.compiler.model.EnumConstant;
 import io.protostuff.compiler.model.Field;
@@ -180,7 +182,8 @@ public class MessageFieldUtil {
             if (constants.isEmpty()) {
                 defaultValue = "UNRECOGNIZED";
             } else {
-                defaultValue = constants.get(0).getName();
+                DynamicMessage options = field.getOptions();
+                defaultValue = options.containsKey(DEFAULT) ? options.get(DEFAULT).getEnumName() : constants.get(0).getName();
             }
             return UserTypeUtil.getCanonicalName(anEnum) + "." + defaultValue;
         }

--- a/protostuff-generator/src/main/resources/io/protostuff/generator/java/message-base.stg
+++ b/protostuff-generator/src/main/resources/io/protostuff/generator/java/message-base.stg
@@ -32,11 +32,6 @@ message_bit_field(name) ::= <<
 private int <name>;
 >>
 
-
-default_enum_value(enum) ::= <%
-<first(enum.constants):{constant|<constant.javaName>}>
-%>
-
 field_initializer(field) ::= <%
 <if(field.map)>
 this.<field.javaName> = java.util.Collections.emptyMap();
@@ -44,7 +39,7 @@ this.<field.javaName> = java.util.Collections.emptyMap();
 this.<field.javaName> = java.util.Collections.emptyList();
 <elseif(field.oneofPart)>
 <elseif(field.type.enum)>
-this.<field.javaName> = <field.javaType>.<field.type:default_enum_value()>.getNumber();
+this.<field.javaName> = <field.javaDefaultValue>.getNumber();
 <else>
 this.<field.javaName> = <field.javaDefaultValue>;
 <endif>

--- a/protostuff-parser/src/main/java/io/protostuff/compiler/parser/OptionsPostProcessor.java
+++ b/protostuff-parser/src/main/java/io/protostuff/compiler/parser/OptionsPostProcessor.java
@@ -36,7 +36,7 @@ public class OptionsPostProcessor implements ProtoContextPostProcessor {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OptionsPostProcessor.class);
 
-    private static final String DEFAULT = "default";
+    public static final String DEFAULT = "default";
     private static final Map<ScalarFieldType, ValueChecker> SCALAR_ASSIGNMENT_CHECKS = new EnumMap<>(ImmutableMap.<ScalarFieldType, ValueChecker>builder()
             .put(ScalarFieldType.INT32, OptionsPostProcessor::canAssignInt32)
             .put(ScalarFieldType.INT64, OptionsPostProcessor::canAssignInt64)


### PR DESCRIPTION
I found in messages with enums the code generated always defaulted to the first enum in the list despite what was being specified in the message e.g.

message MyMessage {
    optional MyEnum aName = 1 [default = TypeB];

    message MyEnum {
        TypeA = 0;
        TypeB = 1;
    }
}

aName would always be defaulted to TypeA in the code.